### PR TITLE
Update BarcodeScanningProcessor.java

### DIFF
--- a/src/android/src/BarcodeScanningProcessor.java
+++ b/src/android/src/BarcodeScanningProcessor.java
@@ -129,7 +129,7 @@ public class BarcodeScanningProcessor {
 
   private void OnSuccess(List<FirebaseVisionBarcode> p_Barcodes) {
     for(FirebaseVisionBarcode barcode: p_Barcodes) {
-      _BarcodeUpdateListener.onBarcodeDetected(barcode.getRawValue());
+      _BarcodeUpdateListener.onBarcodeDetected(barcode.getDisplayValue());
     }
   }
 


### PR DESCRIPTION
Use the getDisplayValue to prevent having letters at the beginning and the end of CODABAR barcode